### PR TITLE
Add a download agent option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,5 +169,8 @@ cython_debug/
 logs
 
 # Contrast Security
-contrast_security.yaml
+*.jar
 *.env
+*.sha1
+contrast_security.yaml
+maven-metadata.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,13 +9,15 @@ dependencies = [
     "requests>=2.32.0",
     "shellingham>=1.5.4",
     "rich>=13.7.1",
-    "typer[all]>=0.12.3",
+    "typer>=0.12.3",
     "annotated-types>=0.6.0",
     "types-requests>=2.31.0.20240406",
     "jinja2>=3.1.4",
     "pyyaml>=6.0.1",
     "gitpython>=3.1.43",
     "questionary>=2.0.1",
+    "lxml>=5.2.2",
+    "types-lxml>=2024.4.14",
 ]
 license = { file = "LICENSE" }
 readme = "README.md"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -18,6 +18,8 @@ charset-normalizer==3.3.2
 click==8.1.7
     # via black
     # via typer
+cssselect==1.2.0
+    # via types-lxml
 exceptiongroup==1.2.1
     # via pytest
 gitdb==4.0.11
@@ -29,6 +31,8 @@ idna==3.7
 iniconfig==2.0.0
     # via pytest
 jinja2==3.1.4
+    # via c6t
+lxml==5.2.2
     # via c6t
 markdown-it-py==3.0.0
     # via rich
@@ -75,6 +79,12 @@ tomli==2.0.1
     # via pytest
 typer==0.12.3
     # via c6t
+types-beautifulsoup4==4.12.0.20240511
+    # via types-lxml
+types-html5lib==1.1.11.20240228
+    # via types-beautifulsoup4
+types-lxml==2024.4.14
+    # via c6t
 types-requests==2.31.0.20240406
     # via c6t
 typing-extensions==4.11.0
@@ -83,6 +93,7 @@ typing-extensions==4.11.0
     # via mypy
     # via rich
     # via typer
+    # via types-lxml
 urllib3==2.2.1
     # via requests
     # via types-requests

--- a/requirements.lock
+++ b/requirements.lock
@@ -16,6 +16,8 @@ charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via typer
+cssselect==1.2.0
+    # via types-lxml
 gitdb==4.0.11
     # via gitpython
 gitpython==3.1.43
@@ -23,6 +25,8 @@ gitpython==3.1.43
 idna==3.7
     # via requests
 jinja2==3.1.4
+    # via c6t
+lxml==5.2.2
     # via c6t
 markdown-it-py==3.0.0
     # via rich
@@ -50,12 +54,19 @@ smmap==5.0.1
     # via gitdb
 typer==0.12.3
     # via c6t
+types-beautifulsoup4==4.12.0.20240511
+    # via types-lxml
+types-html5lib==1.1.11.20240228
+    # via types-beautifulsoup4
+types-lxml==2024.4.14
+    # via c6t
 types-requests==2.31.0.20240406
     # via c6t
 typing-extensions==4.11.0
     # via annotated-types
     # via rich
     # via typer
+    # via types-lxml
 urllib3==2.2.1
     # via requests
     # via types-requests

--- a/src/c6t/api/maven_repo.py
+++ b/src/c6t/api/maven_repo.py
@@ -1,0 +1,145 @@
+import hashlib
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+import shutil
+import tempfile
+
+import requests
+from rich.progress import Progress
+from rich import print as rprint
+from lxml import etree
+
+session = requests.Session()
+
+
+def verify_file_checksum(
+    target_filename: Path, checksum_filename: Path, algorithm: str
+) -> bool:
+    """
+    Verify the checksum of a file against a checksum file.
+    """
+    rprint(f"[cyan]Verifying checksum for {target_filename.name}...")
+    with open(target_filename, "rb") as f:
+        target_checksum = hashlib.new(
+            algorithm, f.read(), usedforsecurity=True
+        ).hexdigest()
+    with open(checksum_filename, "r") as f:
+        checksum = f.read().strip()
+    if target_checksum != checksum:
+        raise ValueError(f"Checksum does not match for {target_filename.name}.")
+    else:
+        rprint(f"[green]Checksum verified for {target_filename.name}.")
+    return True
+
+
+def download_file(url: str, filename: Path) -> None:
+    rprint(f"[cyan]Starting download from: {url}")
+    with Progress() as progress:
+        task = progress.add_task(f"[cyan]Downloading...", total=100)
+        response = session.get(url, stream=True)
+        response.raise_for_status()
+        total_length = int(response.headers.get("content-length", 0))
+        chunk_size = 4096
+
+        with open(filename, "wb") as f:
+            for data in response.iter_content(chunk_size=chunk_size):
+                f.write(data)
+                progress.update(task, advance=len(data) / total_length * 100)
+    rprint(f"[green]Download completed: {filename.name}")
+
+
+def download_maven_metadata_from_repo(repository_url: str, temp_dir: Path) -> Path:
+    url = f"{repository_url}/com/contrastsecurity/contrast-agent/maven-metadata.xml"
+    filename = temp_dir / "maven-metadata.xml"
+    download_file(url, filename)
+    return filename
+
+
+def download_maven_metadata_checksum_from_repo(
+    repository_url: str, algorithm: str, temp_dir: Path
+) -> Path:
+    filename = temp_dir / f"maven-metadata.xml.{algorithm}"
+    url = f"{repository_url}/com/contrastsecurity/contrast-agent/{filename.name}"
+    download_file(url, filename)
+    return filename
+
+
+def parse_maven_metadata(metadata_file: Path) -> Any:
+    with open(metadata_file, "r") as f:
+        metadata = f.read()
+    tree = etree.parse(BytesIO(metadata.encode("utf-8")))
+    return tree.getroot()
+
+
+def get_latest_version_from_maven_metadata(root: Any) -> str:
+    versioning = root.find("versioning")
+    if versioning is not None:
+        latest = versioning.find("latest")
+        if latest is not None:
+            if latest.text is not None:
+                return latest.text.strip()
+    raise ValueError("Could not find latest version in Maven metadata.")
+
+
+def is_version_in_maven_metadata(root: Any, version: str) -> bool:
+    versioning = root.find("versioning")
+    if versioning is not None:
+        versions = versioning.find("versions")
+        if versions is not None:
+            for v in versions:
+                if v.text is not None and v.text.strip() == version:
+                    return True
+    raise ValueError(f"Version {version} is not in Maven metadata.")
+
+
+def download_java_agent_from_repo(
+    repository_url: str, version: str, target_dir: Path
+) -> Path:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_dir_path = Path(temp_dir)
+        maven_metadata_file = download_maven_metadata_from_repo(
+            repository_url, temp_dir_path
+        )
+        maven_metadata_checksum_file = download_maven_metadata_checksum_from_repo(
+            repository_url, "sha1", temp_dir_path
+        )
+        verify_file_checksum(maven_metadata_file, maven_metadata_checksum_file, "sha1")
+
+        root = parse_maven_metadata(maven_metadata_file)
+
+        if version == "latest":
+            version = get_latest_version_from_maven_metadata(root)
+        else:
+            if not is_version_in_maven_metadata(root, version):
+                raise ValueError(f"Version {version} is not in Maven metadata.")
+
+        jar_filename = temp_dir_path / "contrast.jar"
+        url = f"{repository_url}/com/contrastsecurity/contrast-agent/{version}/contrast-agent-{version}.jar"
+        download_file(url, jar_filename)
+        java_agent_checksum_filename = download_java_agent_checksum_from_repo(
+            repository_url, version, temp_dir_path
+        )
+        verify_file_checksum(jar_filename, java_agent_checksum_filename, "sha1")
+
+        target_jar_path = target_dir / "contrast.jar"
+        shutil.copy(jar_filename, target_jar_path)
+        rprint(f"[green]File copied to {target_jar_path}")
+
+    return target_jar_path
+
+
+def download_java_agent_checksum_from_repo(
+    repository_url: str, version: str, temp_dir: Path, algorithm: str = "sha1"
+) -> Path:
+    if version == "latest":
+        version = get_latest_version_from_maven_metadata(
+            parse_maven_metadata(temp_dir / "maven-metadata.xml")
+        )
+
+    java_agent_checksum_filename = (
+        temp_dir / f"contrast-agent-{version}.jar.{algorithm}"
+    )
+    url = f"{repository_url}/com/contrastsecurity/contrast-agent/{version}/{java_agent_checksum_filename.name}"
+    download_file(url, java_agent_checksum_filename)
+    return java_agent_checksum_filename

--- a/src/c6t/cli.py
+++ b/src/c6t/cli.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from pathlib import Path
 
 import typer
 import yaml
@@ -13,7 +14,7 @@ import questionary
 from c6t.configure.credentials import ContrastAPICredentials
 from c6t.ui.auth import ContrastUIAuthManager
 from c6t.api.agent_config import AgentConfig
-
+from c6t.api.maven_repo import download_java_agent_from_repo
 from c6t.external.integrations.scw.contrast_scw import scw_create, scw_delete
 
 app = typer.Typer()
@@ -161,6 +162,25 @@ def agent_config(
         if path is None:
             path = "contrast.env"
         agent_config.write_agent_config_to_file(path=path, text=rendered_env_text)
+
+
+@app.command("download-agent")
+def download_agent(
+    language: str = "JAVA",
+    repository_url: str = "https://repo1.maven.org/maven2",
+    version: str = "latest",
+    target_dir: Path = Path("."),
+) -> None:
+    """
+    Download the Contrast agent for the specified language.
+    """
+    if language == "JAVA":
+        rprint(f"Downloading Contrast agent ({version})...")
+        download_java_agent_from_repo(
+            repository_url=repository_url, version=version, target_dir=target_dir
+        )
+    else:
+        rprint("Unsupported language")
 
 
 @scw_integration_app.command("create")


### PR DESCRIPTION
New Module: maven_repo.py
- Added a new module src/c6t/api/maven_repo.py to handle:
  - Verification of file checksums.
  - Downloading files from Maven repositories.
  - Parsing Maven metadata to find the latest version or specific versions of artifacts.
  - Handling Java agent downloads, including checksum verification.

CLI Enhancements: cli.py
- Introduced a new command download-agent to the CLI for downloading the Contrast agent:
  - Supports downloading the latest or specific versions.
  - Verifies checksums and handles file operations securely.