### PR TITLE
Preserve Existing Credentials in File

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "c6t"
-version = "0.0.9"
+version = "0.0.10"
 description = "Unofficial Administrative Command Line Interface for Contrast Security"
 authors = [
     { name = "Jonathan Harper", email = "39912347+jharper-sec@users.noreply.github.com" },

--- a/src/c6t/__init__.py
+++ b/src/c6t/__init__.py
@@ -1,2 +1,2 @@
 __app_name__ = "c6t"
-__version__ = "0.0.9"
+__version__ = "0.0.10"

--- a/src/c6t/configure/credentials.py
+++ b/src/c6t/configure/credentials.py
@@ -1,7 +1,5 @@
 import json
-
 from pathlib import Path
-
 import typer
 
 
@@ -62,17 +60,23 @@ class ContrastAPICredentials:
         """
         Write credentials to file in JSON format
         """
-        credentials = {
-            self.profile: {
-                "url": self.base_url,
-                "user_name": self.username,
-                "api_key": self.api_key,
-                "service_key": self.service_key,
-                "organization_id": self.organization_uuid,
-                "superadmin": self.superadmin,
-            }
-        }
         credentials_file_path = Path("~/.c6t/credentials.json").expanduser()
         credentials_file_path.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            with open(credentials_file_path, "r") as credentials_file:
+                credentials = json.load(credentials_file)
+        except FileNotFoundError:
+            credentials = {}
+
+        credentials[self.profile] = {
+            "url": self.base_url,
+            "user_name": self.username,
+            "api_key": self.api_key,
+            "service_key": self.service_key,
+            "organization_id": self.organization_uuid,
+            "superadmin": self.superadmin,
+        }
+
         with open(credentials_file_path, "w") as credentials_file:
             json.dump(credentials, credentials_file, indent=4)


### PR DESCRIPTION
Updated the `write_credentials_to_file` method to preserve existing credentials by reading the current contents of the credentials file, updating it with the new credentials, and writing the updated dictionary back to the file. This prevents overwriting existing credentials when new ones are added or updated.