### PR TITLE
Fixed YAML gen issue for session metadata

### DIFF
--- a/src/c6t/api/agent_config.py
+++ b/src/c6t/api/agent_config.py
@@ -1,6 +1,7 @@
 import httpx
 import base64
 from pathlib import Path
+import yaml
 
 from c6t.configure.credentials import ContrastAPICredentials
 
@@ -53,3 +54,15 @@ class AgentConfig:
         config_path = Path(path)
         with open(config_path, "w") as f:
             f.write(text)
+
+    def validate_agent_config_file_is_valid_yaml(self, path: str) -> bool:
+        """
+        Validate the Agent Config file is valid YAML
+        """
+        config_path = Path(path)
+        with open(config_path, "r") as f:
+            try:
+                yaml.safe_load(f)
+            except yaml.YAMLError:
+                return False
+        return True

--- a/src/c6t/cli.py
+++ b/src/c6t/cli.py
@@ -1,5 +1,6 @@
 from typing import Optional
 from pathlib import Path
+import sys
 
 import typer
 import yaml
@@ -158,6 +159,14 @@ def agent_config(
         if path is None:
             path = "contrast_security.yaml"
         agent_config.write_agent_config_to_file(path=path, text=rendered_yaml_text)
+        rprint(f"Validating agent config file at {path}...")
+        valid = agent_config.validate_agent_config_file_is_valid_yaml(path=path)
+        if valid:
+            rprint(f"[green]Agent config file at {path} is valid")
+        else:
+            rprint(f"[red]Agent config file at {path} is invalid")
+            sys.exit(1)
+
     elif type == "env":
         if path is None:
             path = "contrast.env"

--- a/src/c6t/templates/contrast_security.yaml.j2
+++ b/src/c6t/templates/contrast_security.yaml.j2
@@ -9,12 +9,14 @@ application:
   {% if application_name -%}
   name: {{ application_name }}
   {% endif -%}
-  session_metadata: 
-  {%- if branch_name %} branchName={{ branch_name }},{% endif -%}
+  {%- if branch_name or commit_hash or committer or repository or environment -%}
+  session_metadata: "
+  {%- if branch_name %}branchName={{ branch_name }},{% endif -%}
   {%- if commit_hash %}commitHash={{ commit_hash }},{% endif -%}
   {%- if committer %}committer={{ committer }},{% endif -%}
   {%- if repository %}repository={{ repository }},{% endif -%}
-  {%- if environment %}environment={{ environment }}{% endif %}
+  {%- if environment %}environment={{ environment }}{% endif -%}
+  "{%- endif %}
 server:
   {% if application_name -%}
   name: {{ application_name }}-{{ environment }}


### PR DESCRIPTION
There was an issue with the YAML generation where there was no space between the key and value for session metadata in the case where no git repo existed in the current directory.

This merge fixes this issue as well as adding a YAML validation step after generation.